### PR TITLE
test(integration): add integration smoke test

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,9 @@
+// Integration tests for cowSolver crate.
+// These tests serve as smoke tests ensuring that the crate builds and links correctly.
+// More comprehensive tests should exercise solver, matching, pricing, and other modules end-to-end.
+
+#[test]
+fn integration_smoke_test() {
+    // Simple assertion as a placeholder for integration testing.
+    assert_eq!(2 + 2, 4);
+}


### PR DESCRIPTION
Add `tests/integration_tests.rs` with a simple smoke test to ensure the project builds and links correctly. This placeholder can be expanded with true end-to-end tests in the future. Closes #13.